### PR TITLE
[hotfix]  Unparenthesized `a ? b : c ? d : e`

### DIFF
--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -109,10 +109,7 @@ class FindCommand extends Command
             $original = [];
 
             foreach ($allLanguages as $languageKey) {
-                $original[$languageKey] =
-                    isset($values[$languageKey])
-                        ? $values[$languageKey]
-                        : isset($filesContent[$fileName][$languageKey][$key]) ? $filesContent[$fileName][$languageKey][$key] : '';
+                $original[$languageKey] = isset($values[$languageKey]) ? $values[$languageKey] : (isset($filesContent[$fileName][$languageKey][$key]) ? $filesContent[$fileName][$languageKey][$key] : '');
             }
 
             // Sort the language values based on language name


### PR DESCRIPTION
 Unparenthesized is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`